### PR TITLE
Stop AOT compiling

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,5 +5,4 @@
                  [cheshire "5.4.0"]
                  [slingshot "0.10.3"]
                  [mavericklou/oauth-clj "0.1.4.1"]
-                 [factual/sosueme "0.0.15"]]
-  :aot :all)
+                 [factual/sosueme "0.0.15"]])


### PR DESCRIPTION
I'm not entirely sure why, but AOT compilation causes arcane dependency
issues when compiling ClojureScript. See

https://github.com/travis/factual-cljs-issue

for a minimal failing example. I have tested and confirmed that removing
AOT compilation fixes the issue - see

https://clojars.org/tvachon/factual-clojure-driver